### PR TITLE
Freebase API url has changed

### DIFF
--- a/lib/ken.rb
+++ b/lib/ken.rb
@@ -22,7 +22,7 @@ require dir + 'logger'
 Ken::Logger.new(STDOUT, :error)
 
 # init default session
-Ken::Session.new('http://www.freebase.com', 'ma', 'xxxxx')
+Ken::Session.new('http://api.freebase.com', 'ma', 'xxxxx')
 
 module Ken
   extend Extlib::Assertions


### PR DESCRIPTION
Freebase recently changed their url from http://www.freebase.com/api to http://api.freebase.com/api. The API responds with a redirect, but the gem doesn't support redirects.
